### PR TITLE
fix: getting to build with zig 0.13.0-dev.74, unit test, fix bugs

### DIFF
--- a/bencode_to_yaml.zig
+++ b/bencode_to_yaml.zig
@@ -5,7 +5,7 @@ pub fn main() anyerror!void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     const allocator = gpa.allocator();
 
-    var args = try std.process.argsAlloc(allocator);
+    const args = try std.process.argsAlloc(allocator);
     const arg = if (args.len == 2) args[1] else return error.MissingCliArgument;
 
     const File = std.fs.File;

--- a/build.zig
+++ b/build.zig
@@ -1,14 +1,25 @@
-const Builder = @import("std").build.Builder;
+const std = @import("std");
+const Build = std.Build;
 
-pub fn build(b: *Builder) void {
-    const mode = b.standardReleaseOptions();
-    const lib = b.addStaticLibrary("zig-bencode", "src/main.zig");
-    lib.setBuildMode(mode);
-    lib.install();
-
-    var main_tests = b.addTest("src/main.zig");
-    main_tests.setBuildMode(mode);
+pub fn build(b: *Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
 
     const test_step = b.step("test", "Run library tests");
-    test_step.dependOn(&main_tests.step);
+
+    const lib = b.addStaticLibrary(.{
+        .name = "zig-bencode",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+    b.installArtifact(lib);
+
+    const unit_tests = b.addTest(.{
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+    });
+
+    const run_unit_tests = b.addRunArtifact(unit_tests);
+    test_step.dependOn(&run_unit_tests.step);
 }

--- a/example_decode.zig
+++ b/example_decode.zig
@@ -3,15 +3,15 @@ const bencode = @import("src/main.zig");
 
 pub fn main() anyerror!void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    const allocator = &gpa.allocator;
+    const allocator = gpa.allocator();
     var v = try bencode.ValueTree.parse("d3:agei18e4:name3:joee", allocator);
     defer v.deinit();
 
     if (bencode.mapLookup(v.root.Map, "age")) |age| {
-        if (bencode.isInteger(age.*)) std.debug.warn("age={} ", .{age.Integer});
+        if (bencode.isInteger(age.*)) std.debug.print("age={} ", .{age.Integer});
     }
 
     if (bencode.mapLookup(v.root.Map, "name")) |name| {
-        if (bencode.isString(name.*)) std.debug.warn("name={}\n", .{name.String});
+        if (bencode.isString(name.*)) std.debug.print("name={s}\n", .{name.String});
     }
 }

--- a/example_encode.zig
+++ b/example_encode.zig
@@ -2,8 +2,6 @@ const std = @import("std");
 const bencode = @import("src/main.zig");
 
 pub fn main() anyerror!void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    const allocator = &gpa.allocator;
     const Person = struct {
         age: usize,
         name: []const u8,

--- a/src/main.zig
+++ b/src/main.zig
@@ -183,6 +183,8 @@ pub const Value = union(enum) {
             .Map => |map| {
                 try out_stream.writeByte('d');
                 for (map.items) |kv| {
+                    try std.fmt.format(out_stream, "{}", .{kv.key.len});
+                    try out_stream.writeByte(':');
                     try out_stream.writeAll(kv.key);
                     try stringifyValue(kv.value, out_stream);
                 }
@@ -769,4 +771,16 @@ test "stringify array of structs" {
 test "stringify vector" {
     const result: @Vector(2, u32) = @splat(1);
     try teststringify("li1ei1ee", result);
+}
+
+test "stringifyValue map" {
+    const expectData = "d6:lengthi2715254784e4:name30:ubuntu-20.04-desktop-amd64.iso12:piece lengthi1048576ee";
+    var map_test = try ValueTree.parse(expectData, testing.allocator);
+    defer map_test.deinit();
+
+    var buf = std.ArrayList(u8).init(testing.allocator);
+    defer buf.deinit();
+    try map_test.root.stringifyValue(buf.writer());
+
+    try testing.expectEqualSlices(u8, expectData, buf.items);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -16,8 +16,8 @@ fn outputUnicodeEscape(
         // To escape an extended character that is not in the Basic Multilingual Plane,
         // the character is represented as a 12-character sequence, encoding the UTF-16 surrogate pair.
 
-        const high = @as(u16, (codepoint - 0x10000) >> 10) + 0xD800;
-        const low = @as(u16, codepoint & 0x3FF) + 0xDC00;
+        const high = @as(u21, (codepoint - 0x10000) >> 10) + 0xD800;
+        const low = @as(u21, codepoint & 0x3FF) + 0xDC00;
         try out_stream.writeAll("\\u");
         try std.fmt.formatIntValue(high, "x", std.fmt.FormatOptions{ .width = 4, .fill = '0' }, out_stream);
         try out_stream.writeAll("\\u");

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,7 +15,6 @@ fn outputUnicodeEscape(
         std.debug.assert(codepoint <= 0x10FFFF);
         // To escape an extended character that is not in the Basic Multilingual Plane,
         // the character is represented as a 12-character sequence, encoding the UTF-16 surrogate pair.
-
         const high = @as(u21, (codepoint - 0x10000) >> 10) + 0xD800;
         const low = @as(u21, codepoint & 0x3FF) + 0xDC00;
         try out_stream.writeAll("\\u");
@@ -482,17 +481,17 @@ test "parse into number without digits" {
 }
 
 test "parse into bytes" {
-    const value = (try ValueTree.parse("3:abc", testing.allocator)).root.String;
-    defer testing.allocator.free(value);
+    var parsed_tree = try ValueTree.parse("3:abc", testing.allocator);
+    defer parsed_tree.deinit();
 
-    try expectEqualSlices(u8, value, "abc");
+    try expectEqualSlices(u8, parsed_tree.root.String, "abc");
 }
 
 test "parse into unicode bytes" {
-    const value = (try ValueTree.parse("9:毛泽东", testing.allocator)).root.String;
-    defer testing.allocator.free(value);
+    var parsed_tree = try ValueTree.parse("9:毛泽东", testing.allocator);
+    defer parsed_tree.deinit();
 
-    try expectEqualSlices(u8, value, "毛泽东");
+    try expectEqualSlices(u8, parsed_tree.root.String, "毛泽东");
 }
 
 test "parse into bytes with invalid size" {


### PR DESCRIPTION
## Issue:
- Cannot build with new zig since v0.11.0 due to new build system
https://ziglang.org/download/0.11.0/release-notes.html#Build-System
- When running zig unit-test, reports issues where the allocation size and deallocation size do not match. After conducting some testing, I discovered that we are using a heap arena allocator to allocate memory but using std.testing.allocator() to deallocate memory. This mismatch in deallocators leads to incorrect deallocation
[test_result.log](https://github.com/anacrolix/zig-bencode/files/15286016/test_result.log)
- stringifyValue map type is wrong: encode format is lost some bytes data, just add it in this PR also

This PR to make this library work with new Zig version (tested on v0.13.0-dev.74 Zig), fix bug stringifyValue map is wrong and update code to make unit test working
## Status:
- [x] Run `zig build test` and all test passes
- [x] Run `bencode_to_yaml.zig` and examples success
